### PR TITLE
Feat: 야구 경기 정보 조회 RESTful API 구현 #1 #3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,11 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.jsoup</groupId>
+			<artifactId>jsoup</artifactId>
+			<version>1.20.1</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/blc/blc_backend/BlcBackendApplication.java
+++ b/src/main/java/com/blc/blc_backend/BlcBackendApplication.java
@@ -2,8 +2,10 @@ package com.blc.blc_backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class BlcBackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/blc/blc_backend/game/controller/GameController.java
+++ b/src/main/java/com/blc/blc_backend/game/controller/GameController.java
@@ -1,0 +1,48 @@
+package com.blc.blc_backend.game.controller;
+
+import com.blc.blc_backend.game.dto.GameDetailInfo;
+import com.blc.blc_backend.game.dto.GameListRequest;
+import com.blc.blc_backend.game.dto.GameListResponse;
+import com.blc.blc_backend.game.service.GameService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/games")
+@RequiredArgsConstructor
+@CrossOrigin(origins = "*") // Vue.js 프론트엔드를 위한 CORS 설정
+public class GameController {
+
+    private final GameService gameService;
+
+    /**
+     * 전체 경기 리스트 조회 (페이징, 필터링)
+     * GET /api/games?page=1&size=10&startDate=2024-01-01&endDate=2024-12-31&teamCode=KIA&stadium=잠실
+     */
+    @GetMapping
+    public ResponseEntity<GameListResponse> getGames(GameListRequest request) {
+        try {
+            GameListResponse response = gameService.getGames(request);
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    /**
+     * 특정 경기 상세 조회
+     * GET /api/games/{gameId}
+     */
+    @GetMapping("/{gameId}")
+    public ResponseEntity<GameDetailInfo> getGameById(@PathVariable Long gameId) {
+        try {
+            GameDetailInfo gameDetailInfo = gameService.getGameDetailById(gameId);
+            return ResponseEntity.ok(gameDetailInfo);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.notFound().build();
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+}

--- a/src/main/java/com/blc/blc_backend/game/dto/GameDetailInfo.java
+++ b/src/main/java/com/blc/blc_backend/game/dto/GameDetailInfo.java
@@ -1,0 +1,22 @@
+package com.blc.blc_backend.game.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class GameDetailInfo {
+    private final Long gameId;
+    private final String homeTeamName;
+    private final String homeCode;
+    private final String homeLogoUrl;
+    private final String homeTeamColor;
+    private final String awayTeamName;
+    private final String awayCode;
+    private final String awayLogoUrl;
+    private final String awayTeamColor;
+    private final LocalDateTime gameDateTime;
+    private final String stadium;
+}

--- a/src/main/java/com/blc/blc_backend/game/dto/GameInfo.java
+++ b/src/main/java/com/blc/blc_backend/game/dto/GameInfo.java
@@ -1,0 +1,16 @@
+package com.blc.blc_backend.game.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class GameInfo {
+    private final String homeCode;
+    private final String awayCode;
+    private final LocalDateTime gameDateTime;
+    private final String stadium;
+}
+

--- a/src/main/java/com/blc/blc_backend/game/dto/GameListRequest.java
+++ b/src/main/java/com/blc/blc_backend/game/dto/GameListRequest.java
@@ -1,0 +1,28 @@
+package com.blc.blc_backend.game.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+public class GameListRequest {
+    private int page = 1;
+    private int size = 10;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate startDate;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate endDate;
+
+    private String teamCode; // 특정 팀의 경기만 조회
+    private String stadium;  // 특정 구장의 경기만 조회
+
+    // 페이징을 위한 offset 계산
+    public int getOffset() {
+        return (page - 1) * size;
+    }
+}

--- a/src/main/java/com/blc/blc_backend/game/dto/GameListResponse.java
+++ b/src/main/java/com/blc/blc_backend/game/dto/GameListResponse.java
@@ -1,0 +1,18 @@
+package com.blc.blc_backend.game.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class GameListResponse {
+    private final List<GameInfo> games;
+    private final int currentPage;
+    private final int totalPages;
+    private final long totalCount;
+    private final int pageSize;
+    private final boolean hasNext;
+    private final boolean hasPrevious;
+}

--- a/src/main/java/com/blc/blc_backend/game/entity/Game.java
+++ b/src/main/java/com/blc/blc_backend/game/entity/Game.java
@@ -1,0 +1,42 @@
+package com.blc.blc_backend.game.entity;
+
+import com.blc.blc_backend.team.entity.Team;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "games")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Game {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long gameId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "home_team_id", nullable = false)
+    private Team homeTeam;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "away_team_id", nullable = false)
+    private Team awayTeam;
+
+    @Column(name = "game_date", nullable = false)
+    private LocalDateTime gameDate;
+
+    private String stadium;
+
+    @Builder
+    public Game(Long gameId, Team homeTeam, Team awayTeam, LocalDateTime gameDate, String stadium) {
+        this.gameId = gameId;
+        this.homeTeam = homeTeam;
+        this.awayTeam = awayTeam;
+        this.gameDate = gameDate;
+        this.stadium = stadium;
+    }
+}

--- a/src/main/java/com/blc/blc_backend/game/mapper/GameMapper.java
+++ b/src/main/java/com/blc/blc_backend/game/mapper/GameMapper.java
@@ -1,0 +1,28 @@
+package com.blc.blc_backend.game.mapper;
+
+import com.blc.blc_backend.game.dto.GameInfo;
+import com.blc.blc_backend.game.dto.GameDetailInfo;
+import com.blc.blc_backend.game.dto.GameListRequest;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface GameMapper {
+
+    /**
+     * 전체 경기 리스트 조회 (페이징, 필터링)
+     */
+    List<GameInfo> findGames(GameListRequest request);
+
+    /**
+     * 전체 경기 수 조회 (필터링 조건 포함)
+     */
+    long countGames(GameListRequest request);
+
+    /**
+     * 특정 경기 상세 조회 (ID 기준) - 상세 정보 포함
+     */
+    GameDetailInfo findGameDetailById(@Param("gameId") Long gameId);
+}

--- a/src/main/java/com/blc/blc_backend/game/repository/GameRepository.java
+++ b/src/main/java/com/blc/blc_backend/game/repository/GameRepository.java
@@ -1,0 +1,13 @@
+package com.blc.blc_backend.game.repository;
+
+import com.blc.blc_backend.game.entity.Game;
+import com.blc.blc_backend.team.entity.Team;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+
+@Repository
+public interface GameRepository extends JpaRepository<Game, Long> {
+    boolean existsByHomeTeamAndAwayTeamAndGameDate(Team home, Team away, LocalDateTime date);
+}

--- a/src/main/java/com/blc/blc_backend/game/scheduler/ScheduleCrawlerScheduler.java
+++ b/src/main/java/com/blc/blc_backend/game/scheduler/ScheduleCrawlerScheduler.java
@@ -1,0 +1,22 @@
+// ScheduleCrawlerScheduler.java
+package com.blc.blc_backend.game.scheduler;
+
+import com.blc.blc_backend.game.service.ScheduleCrawlerService;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Component
+@RequiredArgsConstructor
+public class ScheduleCrawlerScheduler {
+
+    private final ScheduleCrawlerService crawlerService;
+
+    @Scheduled(cron = "${crawler.schedule.cron}", zone = "${crawler.schedule.zone}")
+    public void runDailyCrawl() {
+        crawlerService.crawlGameInfo(LocalDate.now());
+    }
+}

--- a/src/main/java/com/blc/blc_backend/game/service/GameService.java
+++ b/src/main/java/com/blc/blc_backend/game/service/GameService.java
@@ -1,0 +1,49 @@
+package com.blc.blc_backend.game.service;
+
+import com.blc.blc_backend.game.dto.GameInfo;
+import com.blc.blc_backend.game.dto.GameDetailInfo;
+import com.blc.blc_backend.game.dto.GameListRequest;
+import com.blc.blc_backend.game.dto.GameListResponse;
+import com.blc.blc_backend.game.mapper.GameMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GameService {
+
+    private final GameMapper gameMapper;
+
+    /**
+     * 전체 경기 리스트 조회 (페이징, 필터링)
+     */
+    public GameListResponse getGames(GameListRequest request) {
+        List<GameInfo> games = gameMapper.findGames(request);
+        long totalCount = gameMapper.countGames(request);
+
+        int totalPages = (int) Math.ceil((double) totalCount / request.getSize());
+
+        return GameListResponse.builder()
+                .games(games)
+                .currentPage(request.getPage())
+                .totalPages(totalPages)
+                .totalCount(totalCount)
+                .pageSize(request.getSize())
+                .hasNext(request.getPage() < totalPages)
+                .hasPrevious(request.getPage() > 1)
+                .build();
+    }
+
+    /**
+     * 특정 경기 상세 조회
+     */
+    public GameDetailInfo getGameDetailById(Long gameId) {
+        GameDetailInfo gameDetailInfo = gameMapper.findGameDetailById(gameId);
+        if (gameDetailInfo == null) {
+            throw new IllegalArgumentException("해당 경기를 찾을 수 없습니다. ID: " + gameId);
+        }
+        return gameDetailInfo;
+    }
+}

--- a/src/main/java/com/blc/blc_backend/game/service/ScheduleCrawlerService.java
+++ b/src/main/java/com/blc/blc_backend/game/service/ScheduleCrawlerService.java
@@ -1,0 +1,136 @@
+package com.blc.blc_backend.game.service;
+
+import com.blc.blc_backend.game.dto.GameInfo;
+import com.blc.blc_backend.game.entity.Game;
+import com.blc.blc_backend.game.repository.GameRepository;
+import com.blc.blc_backend.team.entity.Team;
+import com.blc.blc_backend.team.repository.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduleCrawlerService {
+
+    private static final String GAME_INFO_URL = "https://statiz.sporki.com/schedule/?m=daily&date=";
+    private static final String DATE_TIME_PATTERN = "yyyy-MM-dd";
+    private static final String NOT_FOUND_TEAM_ERROR_FORMAT = "%s 팀이 없습니다.";
+
+
+    private final TeamRepository teamRepo;
+    private final GameRepository gameRepo;
+
+    public void crawlGameInfo(LocalDate date) {
+        try {
+            Document doc = crawl(date);
+            List<GameInfo> gameInfos = getGameInfo(date, doc);
+            saveGameInfo(gameInfos);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public Document crawl(LocalDate date) throws IOException {
+        String url = GAME_INFO_URL + date.format(DateTimeFormatter.ofPattern(DATE_TIME_PATTERN));
+        Document doc = Jsoup.connect(url).get();
+        return doc;
+    }
+
+    private List<GameInfo> getGameInfo(LocalDate date, Document doc) {
+        List<GameInfo> gameInfos = new ArrayList<>();
+
+        Elements games = doc.select("div.box_type_boared div.item_box");
+
+        try {
+            for (Element gameBox : games) {
+                String headText = gameBox.selectFirst("div.sh_box div.box_head").text();
+                // 날짜/시간 (예: "정규06-15 17:00 (잠실) 경기전")
+                Matcher m = Pattern.compile("(\\d{2}-\\d{2})\\s+(\\d{2}:\\d{2})").matcher(headText);
+                if (!m.find()) continue;  // 형식이 다르면 스킵
+
+                String monthDay = m.group(1);
+                String timeStr = m.group(2);
+                LocalDateTime gameDateTime = LocalDateTime.of(
+                        date.withMonth(Integer.parseInt(monthDay.substring(0, 2)))
+                                .withDayOfMonth(Integer.parseInt(monthDay.substring(3, 5))),
+                        LocalTime.parse(timeStr, DateTimeFormatter.ofPattern("HH:mm"))
+                );
+
+                // 구장 정보
+                m = Pattern.compile("\\(([^)]+)\\)").matcher(headText);
+                String stadium = m.find() ? m.group(1) : "";
+
+                // 팀 정보 파싱 (첫 번째 tr=원정, 두 번째 tr=홈)
+                Elements rows = gameBox.select("div.table_type03 table tbody tr");
+                if (rows.size() < 2) {
+                    continue;
+                }
+
+                String awayCode = rows.get(0)
+                        .selectFirst("td.align_left")
+                        .ownText()
+                        .trim();
+                String homeCode = rows.get(1)
+                        .selectFirst("td.align_left")
+                        .ownText()
+                        .trim();
+
+                GameInfo gameInfo = GameInfo.builder()
+                        .awayCode(awayCode)
+                        .homeCode(homeCode)
+                        .gameDateTime(gameDateTime)
+                        .stadium(stadium)
+                        .build();
+
+                // TODO: log 남기기
+                gameInfos.add(gameInfo);
+            }
+        } catch (NullPointerException e) {
+            e.printStackTrace();
+            gameInfos = new ArrayList<>();
+        }
+        return gameInfos;
+    }
+
+    private void saveGameInfo(List<GameInfo> gameInfos) {
+        for (GameInfo gameInfo : gameInfos) {
+            String awayCode = gameInfo.getAwayCode();
+            String homeCode = gameInfo.getHomeCode();
+            LocalDateTime gameDateTime = gameInfo.getGameDateTime();
+            String stadium = gameInfo.getStadium();
+
+            Team away = teamRepo.findByTeamCode(awayCode)
+                    .orElseThrow(() -> new IllegalStateException(String.format(NOT_FOUND_TEAM_ERROR_FORMAT, awayCode)));
+            Team home = teamRepo.findByTeamCode(homeCode)
+                    .orElseThrow(() -> new IllegalStateException(String.format(NOT_FOUND_TEAM_ERROR_FORMAT, homeCode)));
+
+            if (gameRepo.existsByHomeTeamAndAwayTeamAndGameDate(home, away, gameDateTime)) {
+                continue;
+            }
+
+            Game game = Game.builder()
+                    .homeTeam(home)
+                    .awayTeam(away)
+                    .gameDate(gameDateTime)
+                    .stadium(stadium)
+                    .build();
+
+            gameRepo.save(game);
+        }
+    }
+
+}

--- a/src/main/java/com/blc/blc_backend/team/entity/Team.java
+++ b/src/main/java/com/blc/blc_backend/team/entity/Team.java
@@ -1,0 +1,25 @@
+package com.blc.blc_backend.team.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "teams")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Team {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long teamId;
+
+    private String teamName;
+
+    @Column(unique = true)
+    private String teamCode;
+
+    private String logoUrl;
+    private String teamColor;
+    private String league;
+}

--- a/src/main/java/com/blc/blc_backend/team/repository/TeamRepository.java
+++ b/src/main/java/com/blc/blc_backend/team/repository/TeamRepository.java
@@ -1,0 +1,10 @@
+package com.blc.blc_backend.team.repository;
+
+import com.blc.blc_backend.team.entity.Team;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TeamRepository extends JpaRepository<Team, Long> {
+    Optional<Team> findByTeamCode(String teamCode);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,3 +31,8 @@ mybatis.configuration.map-underscore-to-camel-case=true
 # ?? ??
 logging.level.com.baseball.chat=DEBUG
 logging.level.org.springframework.web.socket=DEBUG
+
+# ??? ???? ??
+# ???? ?? ?? 3? ??
+crawler.schedule.cron=0 0 3 * * ?
+crawler.schedule.zone=Asia/Seoul

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,7 +25,7 @@ spring.servlet.multipart.max-request-size=10MB
 
 # MyBatis ??
 mybatis.mapper-locations=classpath:mapper/*.xml
-mybatis.type-aliases-package=com.baseball.chat.entity
+mybatis.type-aliases-package=com.blc.blc_backend
 mybatis.configuration.map-underscore-to-camel-case=true
 
 # ?? ??

--- a/src/main/resources/mapper/GameMapper.xml
+++ b/src/main/resources/mapper/GameMapper.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.blc.blc_backend.game.mapper.GameMapper">
+
+    <!-- 결과 매핑 -->
+    <resultMap id="GameInfoResultMap" type="com.blc.blc_backend.game.dto.GameInfo">
+        <result property="homeCode" column="home_code"/>
+        <result property="awayCode" column="away_code"/>
+        <result property="gameDateTime" column="game_date"/>
+        <result property="stadium" column="stadium"/>
+    </resultMap>
+
+    <!-- 상세 조회용 결과 매핑 -->
+    <resultMap id="GameDetailInfoResultMap" type="com.blc.blc_backend.game.dto.GameDetailInfo">
+        <result property="gameId" column="game_id"/>
+        <result property="homeTeamName" column="home_team_name"/>
+        <result property="homeCode" column="home_code"/>
+        <result property="homeLogoUrl" column="home_logo_url"/>
+        <result property="homeTeamColor" column="home_team_color"/>
+        <result property="awayTeamName" column="away_team_name"/>
+        <result property="awayCode" column="away_code"/>
+        <result property="awayLogoUrl" column="away_logo_url"/>
+        <result property="awayTeamColor" column="away_team_color"/>
+        <result property="gameDateTime" column="game_date"/>
+        <result property="stadium" column="stadium"/>
+    </resultMap>
+
+    <!-- 기본 조인 쿼리 (리스트용) -->
+    <sql id="gameJoinQuery">
+        SELECT
+            ht.team_code as home_code,
+            at.team_code as away_code,
+            g.game_date,
+            g.stadium
+        FROM games g
+                 JOIN teams ht ON g.home_team_id = ht.team_id
+                 JOIN teams at ON g.away_team_id = at.team_id
+    </sql>
+
+    <!-- 상세 조회용 조인 쿼리 -->
+    <sql id="gameDetailJoinQuery">
+        SELECT
+            g.game_id,
+            ht.team_name as home_team_name,
+            ht.team_code as home_code,
+            ht.logo_url as home_logo_url,
+            ht.team_color as home_team_color,
+            at.team_name as away_team_name,
+            at.team_code as away_code,
+            at.logo_url as away_logo_url,
+            at.team_color as away_team_color,
+            g.game_date,
+            g.stadium
+        FROM games g
+                 JOIN teams ht ON g.home_team_id = ht.team_id
+                 JOIN teams at ON g.away_team_id = at.team_id
+    </sql>
+
+    <!-- 필터링 조건 -->
+    <sql id="whereConditions">
+        <where>
+            <if test="startDate != null">
+                <![CDATA[
+                AND DATE(g.game_date) >= #{startDate}
+                ]]>
+            </if>
+            <if test="endDate != null">
+                <![CDATA[
+                AND DATE(g.game_date) <= #{endDate}
+                ]]>
+            </if>
+            <if test="teamCode != null and teamCode != ''">
+                AND (ht.team_code = #{teamCode} OR at.team_code = #{teamCode})
+            </if>
+            <if test="stadium != null and stadium != ''">
+                AND g.stadium LIKE CONCAT('%', #{stadium}, '%')
+            </if>
+        </where>
+    </sql>
+
+    <!-- 전체 경기 리스트 조회 -->
+    <select id="findGames" parameterType="com.blc.blc_backend.game.dto.GameListRequest"
+            resultMap="GameInfoResultMap">
+        <include refid="gameJoinQuery"/>
+        <include refid="whereConditions"/>
+        ORDER BY g.game_date DESC
+        LIMIT #{size} OFFSET #{offset}
+    </select>
+
+    <!-- 전체 경기 수 조회 -->
+    <select id="countGames" parameterType="com.blc.blc_backend.game.dto.GameListRequest"
+            resultType="long">
+        SELECT COUNT(*)
+        FROM games g
+        JOIN teams ht ON g.home_team_id = ht.team_id
+        JOIN teams at ON g.away_team_id = at.team_id
+        <include refid="whereConditions"/>
+    </select>
+
+    <!-- 특정 경기 상세 조회 -->
+    <select id="findGameDetailById" parameterType="long" resultMap="GameDetailInfoResultMap">
+        <include refid="gameDetailJoinQuery"/>
+        WHERE g.game_id = #{gameId}
+    </select>
+
+</mapper>

--- a/src/test/java/com/blc/blc_backend/game/service/ScheduleCrawlerServiceTest.java
+++ b/src/test/java/com/blc/blc_backend/game/service/ScheduleCrawlerServiceTest.java
@@ -1,0 +1,122 @@
+package com.blc.blc_backend.game.service;
+
+import com.blc.blc_backend.game.entity.Game;
+import com.blc.blc_backend.game.repository.GameRepository;
+import com.blc.blc_backend.team.entity.Team;
+import com.blc.blc_backend.team.repository.TeamRepository;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ScheduleCrawlerServiceTest {
+
+    @Mock
+    private TeamRepository teamRepo;
+
+    @Mock
+    private GameRepository gameRepo;
+
+    // crawl(...) 메서드를 오버라이드하기 위해 서비스에 스파이 적용
+    private ScheduleCrawlerService service;
+
+    // 최소 HTML 스니펫(경기 블록 1개)
+    private static final String SAMPLE_HTML = """
+        <div class="box_type_boared">
+          <div class="item_box">
+            <div class="sh_box">
+              <div class="box_head">정규06-15 17:00 (잠실) 경기전</div>
+            </div>
+            <div class="table_type03">
+              <table>
+                <tbody>
+                  <tr>
+                    <td class="align_left"><img src=""/> 롯데</td>
+                  </tr>
+                  <tr>
+                    <td class="align_left"><img src=""/> SSG</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+        """;
+
+    @BeforeEach
+    void setUp() {
+        // Mockito 어노테이션 초기화
+        MockitoAnnotations.openMocks(this);
+        // 실제 서비스 인스턴스에 스파이를 적용해 crawl() 제어 가능
+        service = Mockito.spy(new ScheduleCrawlerService(teamRepo, gameRepo));
+    }
+
+    @Test
+    void crawlGameInfo_savesNewGame() throws IOException {
+        LocalDate date = LocalDate.of(2025, 6, 15);
+
+        // 1) crawl(date) 호출 시 SAMPLE_HTML을 파싱한 Document를 반환하도록 설정
+        Document doc = Jsoup.parse(SAMPLE_HTML);
+        doReturn(doc).when(service).crawl(date);
+
+        // 2) 팀 리포지토리 반환값 설정
+        Team away = Team.builder().teamCode("롯데").build();
+        Team home = Team.builder().teamCode("SSG").build();
+        when(teamRepo.findByTeamCode("롯데")).thenReturn(Optional.of(away));
+        when(teamRepo.findByTeamCode("SSG")).thenReturn(Optional.of(home));
+
+        // 3) 해당 경기가 아직 존재하지 않는 경우 시뮬레이션
+        LocalDateTime expectedDateTime = LocalDateTime.of(date, LocalTime.of(17, 0));
+        when(gameRepo.existsByHomeTeamAndAwayTeamAndGameDate(home, away, expectedDateTime))
+                .thenReturn(false);
+
+        // 4) 테스트 실행
+        service.crawlGameInfo(date);
+
+        // 5) gameRepo.save(...)가 한 번만 호출되었는지 검증하고, 저장된 Game 객체 필드 검사
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Game> captor = ArgumentCaptor.forClass(Game.class);
+        verify(gameRepo, times(1)).save(captor.capture());
+
+        Game saved = captor.getValue();
+        assertEquals(home, saved.getHomeTeam(), "홈팀이 정확히 매핑되어야 합니다.");
+        assertEquals(away, saved.getAwayTeam(), "어웨이팀이 정확히 매핑되어야 합니다.");
+        assertEquals(expectedDateTime, saved.getGameDate(), "경기 시간이 정확히 매핑되어야 합니다.");
+        assertEquals("잠실", saved.getStadium(), "경기장이 정확히 매핑되어야 합니다.");
+    }
+
+    @Test
+    void crawlGameInfo_skipsExistingGame() throws IOException {
+        LocalDate date = LocalDate.of(2025, 6, 15);
+
+        // crawl(date) 호출 시 동일한 Document 반환
+        Document doc = Jsoup.parse(SAMPLE_HTML);
+        doReturn(doc).when(service).crawl(date);
+
+        // 팀 조회 스텁 설정
+        Team away = Team.builder().teamCode("롯데").build();
+        Team home = Team.builder().teamCode("SSG").build();
+        when(teamRepo.findByTeamCode("롯데")).thenReturn(Optional.of(away));
+        when(teamRepo.findByTeamCode("SSG")).thenReturn(Optional.of(home));
+
+        // 이미 해당 경기가 존재하는 경우 시뮬레이션
+        LocalDateTime expectedDateTime = LocalDateTime.of(date, LocalTime.of(17, 0));
+        when(gameRepo.existsByHomeTeamAndAwayTeamAndGameDate(home, away, expectedDateTime))
+                .thenReturn(true);
+
+        // 실행
+        service.crawlGameInfo(date);
+
+        // save()가 호출되지 않음을 검증
+        verify(gameRepo, never()).save(any(Game.class));
+    }
+}


### PR DESCRIPTION
# 📌 Summary
야구 게임 채팅 플랫폼을 위한 경기 정보 조회 API를 구현했습니다. MyBatis 기반으로 페이징, 필터링이 지원되는 경기 리스트 조회와 상세 경기 정보 조회 기능을 제공합니다.

# ✅ Changes
Feat: 전체 경기 리스트 조회 API 구현 (GET /api/games)
페이징 지원 (page, size 파라미터)
필터링 지원 (날짜 범위, 팀 코드, 구장명)
GameInfo DTO 기반 응답 (homeCode, awayCode, gameDateTime, stadium)
Feat: 특정 경기 상세 조회 API 구현 (GET /api/games/{gameId})
팀 상세 정보 포함 (팀명, 로고, 색상 등)
GameDetailInfo DTO 기반 풍부한 정보 제공
Add: MyBatis XML 매퍼를 통한 복잡한 조인 쿼리 구현
games와 teams 테이블 조인으로 팀 정보 통합 조회
XML 특수문자 처리 (CDATA 블록 적용)
Add: 완전한 계층형 아키텍처 구현
Controller, Service, Mapper 레이어 분리
적절한 예외 처리 및 HTTP 상태 코드 반환

# Details:
GameMapper.xml에서 동적 쿼리를 통한 유연한 필터링 구현
Vue.js 연동을 위한 CORS 설정 추가
기존 GameInfo DTO 구조 유지하면서 확장성 확보
MyBatis 설정 완료 (application.properties 업데이트)

# 🔗 Related Issue
야구 게임 채팅 플랫폼 백엔드 기초 구조 구축 #3 
크롤링 구현 및 스케줄링 구현 #1

# 💬 Additional Notes
데이터베이스 연결 설정 후 즉시 테스트 가능
향후 실시간 채팅 기능과 연동 예정
Vue.js 프론트엔드에서 axios를 통한 API 호출 준비 완료
추가 필터링 옵션 (리그별, 시즌별) 확장 가능한 구조로 설계