### PR TITLE
익명 처리 오류 해결

### DIFF
--- a/src/main/java/com/blc/blc_backend/chat/dto/ChatMessageResponseDto.java
+++ b/src/main/java/com/blc/blc_backend/chat/dto/ChatMessageResponseDto.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Setter
 @Builder
@@ -17,6 +19,7 @@ public class ChatMessageResponseDto {
     private Long teamId;
     private String content;
     private MessageType type;
+    private LocalDateTime createdAt;
 
     public ChatMessageResponseDto(ChatMessage entity, String nickname) {
         this.userId = entity.getUserId();
@@ -24,5 +27,6 @@ public class ChatMessageResponseDto {
         this.teamId = entity.getTeamId();
         this.content = entity.getMessageContent();
         this.type = entity.getMessageType();
+        this.createdAt = entity.getCreatedAt();
     }
 }

--- a/src/main/java/com/blc/blc_backend/chat/entity/ChatMessage.java
+++ b/src/main/java/com/blc/blc_backend/chat/entity/ChatMessage.java
@@ -24,7 +24,7 @@ public class ChatMessage {
     @Column(name = "team_id", nullable = false)
     private Long teamId;
 
-    @Column(name = "user_id", nullable = false)
+    @Column(name = "user_id")
     private Long userId;
 
     @Column(name = "message_content", nullable = false, columnDefinition = "TEXT")


### PR DESCRIPTION
### 문제 상황 1. 익명에 대한 처리 오류
상황: mysql auto increase로 인해,  userId -1 or 0 설정 불가능
-> 가능하지만, 모든 개발 환경마다 미리 익명 user 데이터를 삽입해야하는 오버헤드 발생

해결: 방식 변경 -> chat_message 테이블 userId null 허용으로 변경
-> null 그대로 저장, 불러오면서 "익명" 이름 처리 

### 문제 상황 2. 익명 채팅 순서 오류
상황: 순서 꼬임 오류

해결: dto에 createdAt 추가